### PR TITLE
Add Dockerfile for alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,23 +1,25 @@
-ARG RESTY_IMAGE_BASE="vkill/openresty"
-ARG RESTY_IMAGE_TAG="alpine-fat-with-pcre"
-
+ARG RESTY_IMAGE_BASE="openresty/openresty"
+ARG RESTY_IMAGE_TAG="alpine-fat"
+# require alpine-fat >= 1.15.8.1-3
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
 MAINTAINER vkill <vkill.net@gmail.com>
 
-# or master
+#
+# docker build -t apisix:v0.5-alpine -f alpine/Dockerfile alpine
+# docker build -t apisix:dev-alpine --build-arg APISIX_VERSION=master --build-arg APISIX_DOWNLOAD_SHA256=SKIP -f alpine/Dockerfile alpine
+# docker build -t apisix:my-alpine --build-arg APISIX_GITHUB_REPO=https://github.com/YOU/apisix --build-arg APISIX_VERSION=BRANCHNAME --build-arg APISIX_DOWNLOAD_SHA256=SKIP -f alpine/Dockerfile alpine
+#
 ARG APISIX_VERSION=v0.5
 ENV APISIX_VERSION=${APISIX_VERSION}
-
-ENV APISIX_DOWNLOAD_URL https://github.com/iresty/apisix/archive/${APISIX_VERSION}.zip
-
-# or SKIP
+ARG APISIX_GITHUB_REPO=https://github.com/iresty/apisix
+ENV APISIX_DOWNLOAD_URL ${APISIX_GITHUB_REPO}/archive/${APISIX_VERSION}.zip
 ARG APISIX_DOWNLOAD_SHA256=e6f14dcd58c5ba286ee48f8482a669893560bc2fbc90d6bf52881493ce720fb7
 ENV APISIX_DOWNLOAD_SHA256=${APISIX_DOWNLOAD_SHA256}
 
 RUN set -ex \
   \
-  && sed -i 's!dl-cdn.alpinelinux.org!mirrors.aliyun.com!' /etc/apk/repositories \
+  # && sed -i 's!dl-cdn.alpinelinux.org!mirrors.aliyun.com!' /etc/apk/repositories \
   \
   && apk add --no-cache --virtual .rundeps \
     curl \
@@ -35,6 +37,11 @@ RUN set -ex \
     cmake \
   \
   && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/bin/lua \
+  && mkdir -p /usr/local/lib/pkgconfig \
+  && mkdir -p /usr/local/include \
+  && ln -sf /usr/local/openresty/pcre/lib/libpcre.so /usr/local/lib/libpcre.so \
+  && ln -sf /usr/local/openresty/pcre/lib/pkgconfig/libpcre.pc /usr/local/lib/pkgconfig/libpcre.pc \
+  && ln -sf /usr/local/openresty/pcre/include/pcre.h /usr/local/include/pcre.h \
   \
   && wget -O apisix.zip "${APISIX_DOWNLOAD_URL}" \
   && [[ "${APISIX_DOWNLOAD_SHA256}" = "SKIP" ]] && echo "SKIP" || (echo "${APISIX_DOWNLOAD_SHA256} *apisix.zip" | sha256sum -c -) \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -64,4 +64,6 @@ RUN set -ex \
 
 WORKDIR /usr/local/apisix
 
+EXPOSE 9080 9443
+
 CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,60 @@
+ARG RESTY_IMAGE_BASE="vkill/openresty"
+ARG RESTY_IMAGE_TAG="alpine-fat-with-pcre"
+
+FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
+
+MAINTAINER vkill <vkill.net@gmail.com>
+
+# or master
+ARG APISIX_VERSION=v0.5
+ENV APISIX_VERSION=${APISIX_VERSION}
+
+ENV APISIX_DOWNLOAD_URL https://github.com/iresty/apisix/archive/${APISIX_VERSION}.zip
+
+# or SKIP
+ARG APISIX_DOWNLOAD_SHA256=e6f14dcd58c5ba286ee48f8482a669893560bc2fbc90d6bf52881493ce720fb7
+ENV APISIX_DOWNLOAD_SHA256=${APISIX_DOWNLOAD_SHA256}
+
+RUN set -ex \
+  \
+  && sed -i 's!dl-cdn.alpinelinux.org!mirrors.aliyun.com!' /etc/apk/repositories \
+  \
+  && apk add --no-cache --virtual .rundeps \
+    curl \
+  \
+  && apk add --no-cache --virtual .builddeps \
+    unzip \
+    build-base \
+    make \
+    sudo \
+    git \
+    automake \
+    autoconf \
+    libtool \
+    pkgconfig \
+    cmake \
+  \
+  && ln -sf /usr/local/openresty/luajit/bin/luajit /usr/bin/lua \
+  \
+  && wget -O apisix.zip "${APISIX_DOWNLOAD_URL}" \
+  && [[ "${APISIX_DOWNLOAD_SHA256}" = "SKIP" ]] && echo "SKIP" || (echo "${APISIX_DOWNLOAD_SHA256} *apisix.zip" | sha256sum -c -) \
+  \
+  && mkdir -p /usr/src \
+  && unzip apisix.zip -d /usr/src \
+  && rm apisix.zip \
+  \
+  && cd "/usr/src/apisix-`echo ${APISIX_VERSION} | sed 's/^v//'`" \
+  \
+  && make dev \
+  && make install \
+  && cp -r deps /usr/local/apisix/ \
+  && sed -i '/pcall(require, "cjson")$/,/^end$/s/return$/-- return/' /usr/bin/apisix \
+  \
+  && cd / \
+  && rm -r "/usr/src/apisix-`echo ${APISIX_VERSION} | sed 's/^v//'`" \
+  \
+  && apk del .builddeps
+
+WORKDIR /usr/local/apisix
+
+CMD ["sh", "-c", "/usr/bin/apisix init && /usr/bin/apisix init_etcd && /usr/local/openresty/bin/openresty -p /usr/local/apisix -g 'daemon off;'"]


### PR DESCRIPTION
Hi there

The Dockerfile has been completed, but the official docker image 500 happened when `require "ngx.re"`, I should wait openresty/docker-openresty/pull/113 merge. 

--- 2019-07-12 updated
The official docker image was fixed pcre bug in [1.15.8.1-3](https://github.com/openresty/docker-openresty/blob/master/CHANGELOG.md#11581-3) , and I was modified the Dockerfile.
